### PR TITLE
Add cmake to the list of Linux packages to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The prebuilt image and document are here:
 ## Linux
 - git clone https://github.com/NXPmicro/mfgtools.git
 - cd mfgtools
-- sudo apt-get install libusb-1.0.0-dev libzip-dev libbz2-dev pkg-config
+- sudo apt-get install cmake libusb-1.0.0-dev libzip-dev libbz2-dev pkg-config
 - cmake .
 - make
 


### PR DESCRIPTION
Note: in Ubuntu 16.02, the provided cmake's version is too old and should be recompiled from sources.