### PR TITLE
fix the SDPV/SPL config and jump addr for technexion pico-imx6ul

### DIFF
--- a/libuuu/config.cpp
+++ b/libuuu/config.cpp
@@ -67,6 +67,7 @@ Config::Config()
 	emplace_back(ConfigItem{"SDP:", "MX8MQ",   "MX8MQ", NXP_VID, 0x012B});
 	emplace_back(ConfigItem{"SDPU:", "SPL",    "SPL",  0x0525, 0xB4A4, 0,      0x04FF});
 	emplace_back(ConfigItem{"SDPV:", "SPL1",   "SPL",  0x0525, 0xB4A4, 0x0500, 0x9998});
+	emplace_back(ConfigItem("SDPV:", "SPL1",   "SPL",  0x0525, 0x0151, 0x0500, 0x9998));
 	emplace_back(ConfigItem{"SDPU:", "SPL",    "SPL",  0x0525, 0xB4A4, 0x9999, 0x9999}); /*old i.MX8 MQEVk use bcd 9999*/
 	emplace_back(ConfigItem{"SDPU:", "SPL",    "SPL",  BD_VID, 0x1001, 0,      0x04FF});
 	emplace_back(ConfigItem{"SDPV:", "SPL1",   "SPL",  BD_VID, 0x1001, 0x0500, 0x9998});

--- a/uuu/emmc_burn_imx6ul_img.lst
+++ b/uuu/emmc_burn_imx6ul_img.lst
@@ -12,7 +12,7 @@ SDP: boot -f _SPL
 # {
 SDPV: delay 1000
 SDPV: write -f  _UBOOT -addr 0x877FFFC0
-SDPV: jump -addr 0x87800000
+SDPV: jump -addr 0x877FFFC0
 # }
 
 

--- a/uuu/multiboard/emmc_imx6ul_img.auto
+++ b/uuu/multiboard/emmc_imx6ul_img.auto
@@ -9,7 +9,7 @@ SDP: boot -f _SPL
 # {
 SDPV: delay 1000
 SDPV: write -f  _UBOOT -addr 0x877FFFC0
-SDPV: jump -addr 0x87800000
+SDPV: jump -addr 0x877FFFC0
 # }
 FB: ucmd setenv fastboot_dev mmc
 FB: ucmd setenv mmcdev ${mmc_dev}


### PR DESCRIPTION
Hello,
expected review time: 10-20minutes + test on HW/build etc.

## Problem: Can not flash a wic to imx6ul target.
Serial-download flashing pico-imx6ul (PICO-PI-IMX6UL Start Kit)  **hangs** during UUU SDP phase.
(Attaching logs of both host and target terminals.)

## Solution:
Adding device ID 0x0151 to the libuuu/config.cpp solved that but then the target cycles through Header "Tag is not an IMX image" and resets. Causing uuu to take another shot at loading SPL and it ends up cycling 'indefinitely'.
Header is found at the 'right' offset 0x87800000. For u-boot.img we just have to jump to the same addr as load-addr.

## Attached files:
(I hope filenames are descriptive enough but feel free to poke for more info if needed)
- **README_testing-notes.txt**
- **testing-logs.zip**
 -- testcmd_burnwic_pico-imx6ul.sh
 -- host-terminal_devID-only.log.txt
 -- host-terminal_no-patch.log.txt
 -- host-terminal_with-patch.log.txt
 -- serial-port_devID-only.log.txt
 -- serial-port_no-patch.log.txt
 -- serial-port_with-patch.log.txt
 -- repo-info.txt

Thank you for consideration and have a good day :-)
[README_testing-notes.txt](https://github.com/TechNexion/imx-mfgtools-tn/files/12778081/README_testing-notes.txt)
[testing-logs.zip](https://github.com/TechNexion/imx-mfgtools-tn/files/12778083/testing-logs.zip)
